### PR TITLE
Refine logistics prompt

### DIFF
--- a/Logistics.js
+++ b/Logistics.js
@@ -140,6 +140,7 @@ function generateAILogisticsList(selectedItems) {
 
     Focus on the logistics for these specific parts of the event:
     ${scheduleContext}
+    Do NOT include volunteers, staff, or any people. Only list physical items, equipment, or supplies.
     For each item, specify which part it is for using the "relatedScheduleItem" key. You MUST use one of these exact names: ${selectedItems.join(', ')}.
 
     Return a JSON object with a single key "logistics" containing an array of objects.


### PR DESCRIPTION
## Summary
- clarify the AI instructions for generating the logistics list so that people are not treated as logistics items

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684454e4fdb08322909ebca6997c7437