### PR TITLE
Unify brand colors

### DIFF
--- a/Budget.js
+++ b/Budget.js
@@ -33,7 +33,7 @@ function setupBudgetSheet(ss) {
   
   // Format headers
   budgetSheet.getRange(1, 1, 1, headers.length)
-    .setBackground('#4a86e8')
+    .setBackground('#674ea7')
     .setFontColor('#ffffff')
     .setFontWeight('bold')
     .setHorizontalAlignment('center');
@@ -137,7 +137,7 @@ function setupBudgetSheet(ss) {
   // Highlight specific rows with blue background and white text
   const blueRows = [2, 20, 22, 58, 60]; // Revenue (2), Total Revenue (20), Expenses (22), Total Expenses (58), Net Balance (60)
   budgetSheet.getRangeList(blueRows.map(r => `A${r}:F${r}`))
-    .setBackground('#4a86e8')
+    .setBackground('#674ea7')
     .setFontColor('#ffffff')
     .setFontWeight('bold');
   

--- a/Dashboard.js
+++ b/Dashboard.js
@@ -341,7 +341,7 @@ function setupDashboard(ss) {
   buttonCell.setValue('🔄 Refresh')
            .setFontWeight('bold')
            .setFontColor('#ffffff')
-           .setBackground('#4CAF50')
+           .setBackground('#674ea7')
            .setHorizontalAlignment('center');
   sheet.setColumnWidth(8, 100);
   

--- a/EmailDialog.html
+++ b/EmailDialog.html
@@ -4,9 +4,14 @@
     <base target="_top">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
     <style>
+      :root {
+        --primary-color: #674ea7;
+        --primary-hover: #583d94;
+        --background-color: #f9f8fe;
+      }
       body {
         font-family: 'Inter', sans-serif;
-        background-color: #f8f9fa;
+        background-color: var(--background-color);
         font-size: 14px;
         line-height: 1.5;
       }
@@ -34,13 +39,13 @@
         padding: 10px 15px;
         border: none;
         border-radius: 4px;
-        background-color: #4285f4;
+        background-color: var(--primary-color);
         color: white;
         cursor: pointer;
         font-size: 14px;
         margin-top: 20px;
       }
-      button:hover { background-color: #357ae8; }
+      button:hover { background-color: var(--primary-hover); }
       .info { margin-top: 15px; color: #555; }
       .note {
         font-size: 12px;

--- a/EventDescription.js
+++ b/EventDescription.js
@@ -32,7 +32,7 @@ function setupEventDescriptionSheet(ss) {
     'Profit Goal ($)'
   ];
   sheet.getRange(1, 1, 1, 2).setValues([headers])
-    .setBackground('#4a86e8')
+    .setBackground('#674ea7')
     .setFontColor('#ffffff')
     .setFontWeight('bold');
   const data = fields.map(f => [f, '']);

--- a/GenerateCueSheet.js
+++ b/GenerateCueSheet.js
@@ -135,7 +135,7 @@ function setupProfessionalCueSheetHeaders(sheet) {
   ];
   const headerRange = sheet.getRange(8, 1, 1, headers.length); // Now 9 columns
   headerRange.setValues([headers])
-    .setBackground('#1c4587')
+    .setBackground('#583d94')
     .setFontColor('#ffffff')
     .setFontWeight('bold')
     .setFontSize(12)

--- a/People.js
+++ b/People.js
@@ -289,7 +289,7 @@ function setupPeopleSheet(ss, addSampleData = true) {
   
   // Format headers with blue background and white text
   sheet.getRange(1, 1, 1, headers.length)
-    .setBackground('#4a86e8') // Blue background
+    .setBackground('#674ea7') // Brand background
     .setFontColor('#ffffff') // White text
     .setFontWeight('bold')
     .setHorizontalAlignment('center');

--- a/Schedule.js
+++ b/Schedule.js
@@ -79,7 +79,7 @@ function setupScheduleSheet(ss, addSampleData = true) {
   
   // Format headers with blue background and white text
   sheet.getRange(1, 1, 1, headers.length)
-    .setBackground('#4a86e8') // Blue background
+    .setBackground('#674ea7') // Brand background
     .setFontColor('#ffffff') // White text
     .setFontWeight('bold')
     .setHorizontalAlignment('center');

--- a/TaskManagement.js
+++ b/TaskManagement.js
@@ -205,7 +205,7 @@ function setupTaskManagementSheet(ss, addSampleData = false) {
   
   // Format headers with blue background and white text
   sheet.getRange(1, 1, 1, headers.length)
-    .setBackground('#4a86e8') // Blue background
+    .setBackground('#674ea7') // Brand background
     .setFontColor('#ffffff') // White text
     .setFontWeight('bold')
     .setHorizontalAlignment('center');
@@ -764,7 +764,7 @@ function addTasksToSheet(tasks, eventInfo) {
     
     // Format header row
     taskSheet.getRange(1, 1, 1, headers.length)
-      .setBackground('#4a86e8')
+      .setBackground('#674ea7')
       .setFontColor('#ffffff')
       .setFontWeight('bold')
       .setHorizontalAlignment('center');

--- a/TutorialGenerator.js
+++ b/TutorialGenerator.js
@@ -72,7 +72,7 @@ function initializeTutorialTracking(ss) {
   
   // Format the header
   configSheet.getRange(startRow, 1, 1, 2)
-    .setBackground('#4a86e8')
+    .setBackground('#583d94')
     .setFontColor('#ffffff')
     .setFontWeight('bold');
 }
@@ -92,7 +92,7 @@ function addEventDescriptionTutorial(ss) {
   sheet.getRange(1, tutorialCol, 1, 2).merge();
   sheet.getRange(1, tutorialCol).setValue('📚 Getting Started: Step 1 / 8');
   sheet.getRange(1, tutorialCol)
-    .setBackground('#4285f4')
+    .setBackground('#583d94')
     .setFontColor('#ffffff')
     .setFontWeight('bold')
     .setFontSize(12)
@@ -149,7 +149,7 @@ function addEventDescriptionTutorial(ss) {
   
   // Add border around tutorial
   sheet.getRange(1, tutorialCol, tutorialContent.length + 3, 2)
-    .setBorder(true, true, true, true, true, true, '#4285f4', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
+    .setBorder(true, true, true, true, true, true, '#583d94', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
 }
 
 /**
@@ -166,7 +166,7 @@ function addPeopleTutorial(ss) {
   sheet.getRange(1, tutorialCol, 1, 2).merge();
   sheet.getRange(1, tutorialCol).setValue('📚 Getting Started: Step 2 / 8');
   sheet.getRange(1, tutorialCol)
-    .setBackground('#4285f4')
+    .setBackground('#583d94')
     .setFontColor('#ffffff')
     .setFontWeight('bold')
     .setFontSize(12)
@@ -217,7 +217,7 @@ function addPeopleTutorial(ss) {
   sheet.setColumnWidth(tutorialCol + 1, 200);
   
   sheet.getRange(1, tutorialCol, tutorialContent.length + 3, 2)
-    .setBorder(true, true, true, true, true, true, '#4285f4', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
+    .setBorder(true, true, true, true, true, true, '#583d94', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
 }
 
 /**
@@ -234,7 +234,7 @@ function addTaskManagementTutorial(ss) {
   sheet.getRange(1, tutorialCol, 1, 2).merge();
   sheet.getRange(1, tutorialCol).setValue('📚 Getting Started: Step 3 / 8');
   sheet.getRange(1, tutorialCol)
-    .setBackground('#4285f4')
+    .setBackground('#583d94')
     .setFontColor('#ffffff')
     .setFontWeight('bold')
     .setFontSize(12)
@@ -287,7 +287,7 @@ function addTaskManagementTutorial(ss) {
   sheet.setColumnWidth(tutorialCol + 1, 200);
   
   sheet.getRange(1, tutorialCol, tutorialContent.length + 3, 2)
-    .setBorder(true, true, true, true, true, true, '#4285f4', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
+    .setBorder(true, true, true, true, true, true, '#583d94', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
 }
 
 /**
@@ -304,7 +304,7 @@ function addScheduleTutorial(ss) {
   sheet.getRange(1, tutorialCol, 1, 2).merge();
   sheet.getRange(1, tutorialCol).setValue('📚 Getting Started: Step 4 / 8');
   sheet.getRange(1, tutorialCol)
-    .setBackground('#4285f4')
+    .setBackground('#583d94')
     .setFontColor('#ffffff')
     .setFontWeight('bold')
     .setFontSize(12)
@@ -355,7 +355,7 @@ function addScheduleTutorial(ss) {
   sheet.setColumnWidth(tutorialCol + 1, 200);
   
   sheet.getRange(1, tutorialCol, tutorialContent.length + 3, 2)
-    .setBorder(true, true, true, true, true, true, '#4285f4', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
+    .setBorder(true, true, true, true, true, true, '#583d94', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
 }
 
 /**
@@ -372,7 +372,7 @@ function addBudgetTutorial(ss) {
   sheet.getRange(1, tutorialCol, 1, 2).merge();
   sheet.getRange(1, tutorialCol).setValue('📚 Getting Started: Step 5 / 8');
   sheet.getRange(1, tutorialCol)
-    .setBackground('#4285f4')
+    .setBackground('#583d94')
     .setFontColor('#ffffff')
     .setFontWeight('bold')
     .setFontSize(12)
@@ -425,7 +425,7 @@ function addBudgetTutorial(ss) {
   sheet.setColumnWidth(tutorialCol + 1, 200);
   
   sheet.getRange(1, tutorialCol, tutorialContent.length + 3, 2)
-    .setBorder(true, true, true, true, true, true, '#4285f4', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
+    .setBorder(true, true, true, true, true, true, '#583d94', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
 }
 
 /**
@@ -442,7 +442,7 @@ function addLogisticsTutorial(ss) {
   sheet.getRange(1, tutorialCol, 1, 2).merge();
   sheet.getRange(1, tutorialCol).setValue('📚 Getting Started: Step 6 / 8');
   sheet.getRange(1, tutorialCol)
-    .setBackground('#4285f4')
+    .setBackground('#583d94')
     .setFontColor('#ffffff')
     .setFontWeight('bold')
     .setFontSize(12)
@@ -482,7 +482,7 @@ function addLogisticsTutorial(ss) {
   sheet.setColumnWidth(tutorialCol + 1, 200);
 
   sheet.getRange(1, tutorialCol, tutorialContent.length + 3, 2)
-    .setBorder(true, true, true, true, true, true, '#4285f4', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
+    .setBorder(true, true, true, true, true, true, '#583d94', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
 }
 
 /**
@@ -499,7 +499,7 @@ function addFormsTutorial(ss) {
   sheet.getRange(1, tutorialCol, 1, 2).merge();
   sheet.getRange(1, tutorialCol).setValue('📚 Getting Started: Step 7 / 8');
   sheet.getRange(1, tutorialCol)
-    .setBackground('#4285f4')
+    .setBackground('#583d94')
     .setFontColor('#ffffff')
     .setFontWeight('bold')
     .setFontSize(12)
@@ -537,7 +537,7 @@ function addFormsTutorial(ss) {
   sheet.setColumnWidth(tutorialCol + 1, 200);
 
   sheet.getRange(1, tutorialCol, tutorialContent.length + 3, 2)
-    .setBorder(true, true, true, true, true, true, '#4285f4', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
+    .setBorder(true, true, true, true, true, true, '#583d94', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
 }
 
 /**
@@ -554,7 +554,7 @@ function addDashboardTutorial(ss) {
   sheet.getRange(1, tutorialCol, 1, 2).merge();
   sheet.getRange(1, tutorialCol).setValue('🎉 Getting Started: Step 8 / 8');
   sheet.getRange(1, tutorialCol)
-    .setBackground('#34a853')
+    .setBackground('#583d94')
     .setFontColor('#ffffff')
     .setFontWeight('bold')
     .setFontSize(14)
@@ -615,7 +615,7 @@ function addDashboardTutorial(ss) {
   sheet.setColumnWidth(tutorialCol + 1, 200);
   
   sheet.getRange(1, tutorialCol, tutorialContent.length + 3, 2)
-    .setBorder(true, true, true, true, true, true, '#34a853', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
+    .setBorder(true, true, true, true, true, true, '#583d94', SpreadsheetApp.BorderStyle.SOLID_MEDIUM);
 }
 
 /**

--- a/formTemplates.js
+++ b/formTemplates.js
@@ -25,7 +25,7 @@ function setupFormTemplatesSheet(ss) {
     'Question Title', 'Question Type', 'Options (comma-separated)', 'Is Required?', 'Maps to People Column'
   ];
   sheet.getRange(1, 1, 1, headers.length).setValues([headers])
-    .setBackground('#073763').setFontColor('#ffffff').setFontWeight('bold');
+    .setBackground('#674ea7').setFontColor('#ffffff').setFontWeight('bold');
 
   // Define the default templates
   const templates = [


### PR DESCRIPTION
## Summary
- introduce primary brand colors in `EmailDialog.html`
- adopt the same purple scheme across dialog styles
- apply brand colors to sheet headers and UI elements in scripts

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/LEGIT-EVENTS/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68448ad78ddc83229fb712ef9ce8c885