### PR TITLE
Remove duplicate functions and fix logging

### DIFF
--- a/Core.js
+++ b/Core.js
@@ -307,31 +307,6 @@ function handleSessionStatusChange(e) {
 }
 
 /**
- * Handles edit events in the Dashboard sheet
- * Specifically looks for clicks on the refresh button
- * @param {Object} e The edit event object
- */
-function handleDashboardEdit(e) {
-  // Only proceed if edit is in Dashboard sheet
-  if (!e || !e.range || e.range.getSheet().getName() !== 'Dashboard') return;
-  
-  // Check if the edit is in the refresh button cell (H1)
-  const row = e.range.getRow();
-  const col = e.range.getColumn();
-  
-  if (row === 1 && col === 8) {
-    // User clicked the refresh button
-    setupDashboard();
-    
-    // Show a confirmation toast
-    SpreadsheetApp.getActiveSpreadsheet().toast(
-      'Dashboard refreshed with latest data', 
-      'Refresh Complete', 
-      3);
-  }
-}
-
-/**
  * Updates dashboard task metrics when task status changes
  */
 function updateDashboardTaskMetrics() {
@@ -346,19 +321,6 @@ function updateDashboardTaskMetrics() {
     
   } catch (error) {
     Logger.log(`Error updating dashboard metrics: ${error}`);
-  }
-}
-
-/**
- * Removes all dashboard triggers for auto-update
- */
-function removeAllDashboardTriggers() {
-const allTriggers = ScriptApp.getProjectTriggers();
-  for (let i = 0; i < allTriggers.length; i++) {
-    const trigger = allTriggers[i];
-    if (trigger.getHandlerFunction() === 'handleDashboardEdit') {
-      ScriptApp.deleteTrigger(trigger);
-    }
   }
 }
 

--- a/ScheduleGenerator.js
+++ b/ScheduleGenerator.js
@@ -1135,24 +1135,3 @@ function formatDate(date) {
   
   return `${year}-${month}-${day}`;
 }
-
-/**
- * Gets the OpenAI API key from script properties
- * @return {string|null} The API key or null if not found
- */
-function getOpenAIApiKey() {
-  try {
-    const props = PropertiesService.getScriptProperties();
-    const apiKey = props.getProperty('OPENAI_API_KEY');
-
-    if (apiKey) {
-      return apiKey;
-    }
-
-    Logger.log('OpenAI API key not found in script properties');
-    return null;
-  } catch (e) {
-    Logger.log('Error getting API key: ' + e.toString());
-    return null;
-  }
-}

--- a/SpeakerTaskCreator.js
+++ b/SpeakerTaskCreator.js
@@ -409,9 +409,7 @@ function generateUniqueTaskId() {
 function logError(message, error) {
   if (error) {
     Logger.log(`ERROR: ${message} - ${error.toString()}`);
-    console.error(`ERROR: ${message} - ${error.toString()}`);
   } else {
     Logger.log(`ERROR: ${message}`);
-    console.error(`ERROR: ${message}`);
   }
 }


### PR DESCRIPTION
## Summary
- dedupe dashboard helper functions by keeping them only in `Dashboard.js`
- use `TaskManagement.getOpenAIApiKey` everywhere and remove duplicate helper from `ScheduleGenerator.js`
- drop unsupported `console.error` calls
- clean up leftover comments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68448fb1507083229e6bb56d2bb0dbd8