### PR TITLE
Add folder placement for generated forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ LEGIT Event Planner Pro is a Google Apps Script project for managing events dire
 
 - Automated menu with one-click access to event planning tools.
 - AI-powered generation of preliminary schedules, tasks, logistics lists, and budgets.
-- Form and email generators to streamline communication.
+- Form and email generators to streamline communication. Generated forms are saved in a "[Event Name] Forms" folder next to the spreadsheet.
 - Tools for managing people, schedules, and cues.
 - Modular code organized by feature for easier maintenance.
 


### PR DESCRIPTION
## Summary
- store generated forms in a `[Event Name] Forms` Drive folder located next to the spreadsheet
- document new form storage location

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68449c23b7248322a5e7ac3604bdb0c7