### PR TITLE
Fix new spreadsheet creation and menu

### DIFF
--- a/AutomationTools.js
+++ b/AutomationTools.js
@@ -1,0 +1,45 @@
+// AutomationTools.js - Creates the AI & Automation Tools info sheet
+
+/**
+ * Creates or resets the "AI & Automation Tools" sheet with descriptions of advanced features.
+ * @param {GoogleAppsScript.Spreadsheet.Spreadsheet} ss Optional spreadsheet to operate on.
+ */
+function setupAutomationToolsSheet(ss) {
+  if (!ss) ss = SpreadsheetApp.getActiveSpreadsheet();
+  const ui = SpreadsheetApp.getUi();
+  let sheet = ss.getSheetByName('AI & Automation Tools');
+
+  if (!sheet) {
+    sheet = ss.insertSheet('AI & Automation Tools');
+    sheet.setTabColor('#8e7cc3');
+  } else {
+    const resp = ui.alert('Reset AI & Automation Tools?',
+      'This will clear the sheet and re-add the default information.',
+      ui.ButtonSet.YES_NO);
+    if (resp !== ui.Button.YES) return;
+    sheet.clear();
+  }
+
+  const headers = ['Tool or Sheet', 'Purpose'];
+  sheet.getRange(1, 1, 1, headers.length).setValues([headers])
+    .setBackground('#674ea7')
+    .setFontColor('#ffffff')
+    .setFontWeight('bold');
+
+  const info = [
+    ['AI Generators menu',
+     'Create schedules, task lists, logistics, and budgets with one click.'],
+    ['Cue Builder & Professional Cue Sheet',
+     'Use Production Tools to build cues and generate a professional cue sheet.'],
+    ['Form Templates & Mail Merge',
+     'Generate Google Forms and send bulk emails from the Communication Tools.'],
+    ['Tutorial System', 'Show or hide in-sheet tutorials from the menu.'],
+    ['Create New Event Spreadsheet',
+     'Duplicate this planner with all scripts and base sheets attached.']
+  ];
+
+  sheet.getRange(2, 1, info.length, 2).setValues(info);
+  sheet.setColumnWidth(1, 220);
+  sheet.setColumnWidth(2, 500);
+  sheet.setFrozenRows(1);
+}

--- a/Core.js
+++ b/Core.js
@@ -31,7 +31,14 @@ function onOpen() {
       .addItem('🔄 Refresh Dashboard', 'setupDashboard')
       .addSeparator()
       .addSubMenu(ui.createMenu('⚙️ Sheet Setup')
+        .addItem('Create/Reset Event Description Sheet', 'setupEventDescriptionSheet')
+        .addItem('Create/Reset Config Sheet', 'setupConfigSheet')
+        .addItem('Create/Reset People Sheet', 'setupPeopleSheet')
+        .addItem('Create/Reset Task Management Sheet', 'setupTaskManagementSheet')
+        .addItem('Create/Reset Schedule Sheet', 'setupScheduleSheet')
+        .addItem('Create/Reset Budget Sheet', 'setupBudgetSheet')
         .addItem('Create/Reset Logistics Sheet', 'setupLogisticsSheet')
+        .addItem('Create/Reset AI & Automation Tools Sheet', 'setupAutomationToolsSheet')
         .addItem('Update All Dropdowns', 'updateAllDropdowns'))
       .addSeparator()
       .addSubMenu(ui.createMenu('📚 Tutorial System')
@@ -602,11 +609,17 @@ function createNewEventSpreadsheet() {
   if (templateResp === ui.Button.CANCEL) return;
   const useTemplate = templateResp === ui.Button.YES;
 
-  const newSs = SpreadsheetApp.create(name);
+  // Copy the current spreadsheet so the script project stays attached
+  const copyFile = DriveApp.getFileById(current.getId()).makeCopy(name);
+  const newSs = SpreadsheetApp.openById(copyFile.getId());
 
-  // Remove default blank sheet
-  const firstSheet = newSs.getSheets()[0];
-  if (firstSheet) newSs.deleteSheet(firstSheet);
+  // Remove all sheets except one, then rename it for Event Description
+  const sheets = newSs.getSheets();
+  const firstSheet = sheets[0];
+  for (let i = sheets.length - 1; i > 0; i--) {
+    newSs.deleteSheet(sheets[i]);
+  }
+  if (firstSheet) firstSheet.setName('Event Description');
 
   // Create base sheets
   setupEventDescriptionSheet(newSs);
@@ -614,10 +627,6 @@ function createNewEventSpreadsheet() {
   setupPeopleSheet(newSs, false);
   setupTaskManagementSheet(newSs, false);
   setupScheduleSheet(newSs, false);
-  setupBudgetSheet(newSs);
-  setupLogisticsSheet(newSs);
-  setupFormTemplatesSheet(newSs);
-  setupCueBuilderSheet(newSs);
   setupDashboard(newSs);
 
   if (useTemplate) {

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ LEGIT Event Planner Pro is a Google Apps Script project for managing events dire
 - AI-powered generation of preliminary schedules, tasks, logistics lists, and budgets.
 - Form and email generators to streamline communication. Generated forms are saved in a "[Event Name] Forms" folder next to the spreadsheet.
 - Tools for managing people, schedules, and cues.
+- Dedicated **AI & Automation Tools** sheet to explain advanced menu options.
 - Modular code organized by feature for easier maintenance.
 
 ## Setup
@@ -47,12 +48,19 @@ LEGIT Event Planner Pro is a Google Apps Script project for managing events dire
 6. **Initialize Sheets**
    Run the setup functions from the "Event Planner Pro" menu to create the necessary sheets (Config, Schedule, Logistics, Budget, etc.). These provide templates for your event data and settings.
 
+7. **Create a New Planner**
+   Use **Dashboard & Utilities → Create New Event Spreadsheet** to generate a fresh planner. The new file includes this script project and only the base sheets (Dashboard, Event Description, People, Schedule, Task Management, and Config).
+
+8. **Learn Advanced Tools**
+   Run **Dashboard & Utilities → Create/Reset AI & Automation Tools Sheet** for a quick overview of optional automation features like cue sheets and form generators.
+
 ## Repository Structure
 
 - `Core.js` – Creates the custom menu and houses common utilities.
 - `Config.js` – Handles setup and management of configuration data.
 - `ScheduleGenerator.js` – Generates preliminary schedules using AI services.
 - `Logistics.js`, `Budget.js`, `TaskManagement.js` – Sheets and logic for logistics, budgeting, and tasks.
+- `AutomationTools.js` – Sets up the AI & Automation Tools overview sheet.
 - `MailMerge.js`, `FormGenerator.js` – Communication helpers for emailing and form creation.
 - `appsscript.json` – Google Apps Script project manifest.
 

--- a/TutorialGenerator.js
+++ b/TutorialGenerator.js
@@ -24,8 +24,8 @@ function createFullTutorialSystem() {
     // Add tutorials to each sheet
     addEventDescriptionTutorial(ss);
     addPeopleTutorial(ss);
-    addTaskManagementTutorial(ss);
     addScheduleTutorial(ss);
+    addTaskManagementTutorial(ss);
     addBudgetTutorial(ss);
     addLogisticsTutorial(ss);
     addFormsTutorial(ss);
@@ -60,8 +60,8 @@ function initializeTutorialTracking(ss) {
     ['=== TUTORIAL PROGRESS ===', ''],
     ['Tutorial Step 1 - Event Setup', 'false'],
     ['Tutorial Step 2 - Add People', 'false'],
-    ['Tutorial Step 3 - Generate Tasks', 'false'],
-    ['Tutorial Step 4 - Create Schedule', 'false'],
+    ['Tutorial Step 3 - Create Schedule', 'false'],
+    ['Tutorial Step 4 - Generate Tasks', 'false'],
     ['Tutorial Step 5 - Plan Budget', 'false'],
     ['Tutorial Step 6 - Manage Logistics', 'false'],
     ['Tutorial Step 7 - Generate Forms', 'false'],
@@ -199,7 +199,7 @@ function addPeopleTutorial(ss) {
     ['"Accepted", the system automatically', ''],
     ['creates a task to collect their bio!', ''],
     ['', ''],
-    ['Next: Go to Task Management sheet →', ''],
+    ['Next: Go to Schedule sheet →', ''],
     ['', ''],
     ['🔧 You can also auto-generate forms', ''],
     ['later from the Event Planner Setup menu!', '']
@@ -232,7 +232,7 @@ function addTaskManagementTutorial(ss) {
   
   // Tutorial header
   sheet.getRange(1, tutorialCol, 1, 2).merge();
-  sheet.getRange(1, tutorialCol).setValue('📚 Getting Started: Step 3 / 8');
+  sheet.getRange(1, tutorialCol).setValue('📚 Getting Started: Step 4 / 8');
   sheet.getRange(1, tutorialCol)
     .setBackground('#583d94')
     .setFontColor('#ffffff')
@@ -241,14 +241,14 @@ function addTaskManagementTutorial(ss) {
     .setHorizontalAlignment('center');
   
   // Progress indicators
-  const checkboxes = ['☑️', '☑️', '☑️', '⬜', '⬜', '⬜', '⬜', '⬜'];
+  const checkboxes = ['☑️', '☑️', '☑️', '☑️', '⬜', '⬜', '⬜', '⬜'];
   sheet.getRange(2, tutorialCol, 1, 2).merge();
   sheet.getRange(2, tutorialCol).setValue(checkboxes.join(' '));
   sheet.getRange(2, tutorialCol).setHorizontalAlignment('center');
   
   const tutorialContent = [
     ['', ''],
-    ['Step 3: Generate AI-powered tasks', ''],
+    ['Step 4: Generate AI-powered tasks', ''],
     ['', ''],
     ['🤖 This is where the magic happens!', ''],
     ['', ''],
@@ -272,7 +272,7 @@ function addTaskManagementTutorial(ss) {
     ['💡 You can always add, edit, or delete', ''],
     ['tasks after they\'re generated.', ''],
     ['', ''],
-    ['Next: Go to Schedule sheet →', '']
+    ['Next: Go to Budget sheet →', '']
   ];
   
   sheet.getRange(4, tutorialCol, tutorialContent.length, 2).setValues(tutorialContent);
@@ -302,7 +302,7 @@ function addScheduleTutorial(ss) {
   
   // Tutorial header
   sheet.getRange(1, tutorialCol, 1, 2).merge();
-  sheet.getRange(1, tutorialCol).setValue('📚 Getting Started: Step 4 / 8');
+  sheet.getRange(1, tutorialCol).setValue('📚 Getting Started: Step 3 / 8');
   sheet.getRange(1, tutorialCol)
     .setBackground('#583d94')
     .setFontColor('#ffffff')
@@ -311,14 +311,14 @@ function addScheduleTutorial(ss) {
     .setHorizontalAlignment('center');
   
   // Progress indicators
-  const checkboxes = ['☑️', '☑️', '☑️', '☑️', '⬜', '⬜', '⬜', '⬜'];
+  const checkboxes = ['☑️', '☑️', '☑️', '⬜', '⬜', '⬜', '⬜', '⬜'];
   sheet.getRange(2, tutorialCol, 1, 2).merge();
   sheet.getRange(2, tutorialCol).setValue(checkboxes.join(' '));
   sheet.getRange(2, tutorialCol).setHorizontalAlignment('center');
   
   const tutorialContent = [
     ['', ''],
-    ['Step 4: Create your event schedule', ''],
+    ['Step 3: Create your event schedule', ''],
     ['', ''],
     ['📅 Generate a preliminary schedule:', ''],
     ['', ''],
@@ -340,7 +340,7 @@ function addScheduleTutorial(ss) {
     ['• Lead dropdown pulls from People sheet', ''],
     ['• Time validation prevents conflicts', ''],
     ['', ''],
-    ['Next: Go to Budget sheet →', '']
+    ['Next: Go to Task Management sheet →', '']
   ];
   
   sheet.getRange(4, tutorialCol, tutorialContent.length, 2).setValues(tutorialContent);
@@ -575,8 +575,8 @@ function addDashboardTutorial(ss) {
     ['✨ What you\'ve accomplished:', ''],
     ['• Set up your event basics', ''],
     ['• Added team members', ''],
-    ['• Generated AI-powered tasks', ''],
     ['• Created a preliminary schedule', ''],
+    ['• Generated AI-powered tasks', ''],
     ['• Planned your budget', ''],
     ['• Generated a logistics list', ''],
     ['• Created Google Forms', ''],
@@ -646,7 +646,7 @@ function removeTutorialSystem() {
   
   if (response !== ui.Button.YES) return;
   
-  const sheetNames = ['Event Description', 'People', 'Task Management', 'Schedule', 'Budget', 'Logistics', 'Form Templates', 'Dashboard'];
+  const sheetNames = ['Event Description', 'People', 'Schedule', 'Task Management', 'Budget', 'Logistics', 'Form Templates', 'Dashboard'];
   
   sheetNames.forEach(sheetName => {
     const sheet = ss.getSheetByName(sheetName);


### PR DESCRIPTION
## Summary
- adjust `createNewEventSpreadsheet` to copy the current spreadsheet so the script is attached
- clean out extra sheets and only add Dashboard, Event Description, People, Schedule, Task Management, Config
- document the new planner creation step in the README
- reorder tutorials so schedule comes before task generation
- add new AI & Automation Tools sheet and menu item

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844e7ca34c883228c70706931233e38