### PR TITLE
Implement automatic dropdown refresh

### DIFF
--- a/Core.js
+++ b/Core.js
@@ -617,3 +617,48 @@ function createNewEventSpreadsheet() {
 
   ui.alert('Spreadsheet Created', 'Open the new file: ' + newSs.getUrl(), ui.ButtonSet.OK);
 }
+
+/**
+ * Refreshes dropdown menus across all relevant sheets.
+ */
+function updateAllDropdowns() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const lists = _getConfigLists(ss);
+
+  const peopleSheet = ss.getSheetByName('People');
+  const taskSheet = ss.getSheetByName('Task Management');
+  if (peopleSheet) {
+    const numRows = Math.max(peopleSheet.getMaxRows() - 1, 1);
+    setPeopleDropdowns(peopleSheet, numRows, lists, taskSheet);
+  }
+
+  setScheduleDropdowns(ss, null, null, lists);
+  updateLogisticsDropdowns(ss);
+  updateCueBuilderDropdowns();
+  updateRelatedSessionDropdown(ss);
+}
+
+/**
+ * Creates a daily time-driven trigger for `updateAllDropdowns`.
+ * Run once to enable automatic dropdown refresh.
+ */
+function createDropdownUpdateTrigger() {
+  const triggers = ScriptApp.getProjectTriggers();
+  for (const t of triggers) {
+    if (t.getHandlerFunction() === 'updateAllDropdowns') {
+      ScriptApp.deleteTrigger(t);
+    }
+  }
+
+  ScriptApp.newTrigger('updateAllDropdowns')
+    .timeBased()
+    .everyDays(1)
+    .atHour(2)
+    .create();
+
+  SpreadsheetApp.getActiveSpreadsheet().toast(
+    'Daily dropdown update trigger created.',
+    'Setup Complete',
+    5
+  );
+}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ LEGIT Event Planner Pro is a Google Apps Script project for managing events dire
 8. **Learn Advanced Tools**
    Run **Dashboard & Utilities → Create/Reset AI & Automation Tools Sheet** for a quick overview of optional automation features like cue sheets and form generators.
 
+9. **Enable Automatic Dropdown Updates**
+   In the Apps Script editor run `createDropdownUpdateTrigger()` once. This sets
+   up a daily trigger that refreshes dropdown lists across all sheets.
+
 ## Repository Structure
 
 - `Core.js` – Creates the custom menu and houses common utilities.

--- a/SmartUX.js
+++ b/SmartUX.js
@@ -160,7 +160,6 @@ function addExpertUserMenu(menu, ui) {
       .addItem('📧 Send Emails', 'showEmailDialog'))
     .addSubMenu(ui.createMenu('⚙️ Utilities')
       .addItem('🔧 Configuration', 'setupConfigSheet')
-      .addItem('🔄 Update Dropdowns', 'updateAllDropdowns')
       .addItem('📋 New Event Planner', 'createNewEventSpreadsheet'));
 }
 
@@ -612,7 +611,6 @@ function showProToolsMenu() {
       .addItem('📧 Send Emails', 'showEmailDialog'))
     .addSubMenu(ui.createMenu('⚙️ Utilities')
       .addItem('🔧 Configuration', 'setupConfigSheet')
-      .addItem('🔄 Update Dropdowns', 'updateAllDropdowns')
       .addItem('📋 New Event Planner', 'createNewEventSpreadsheet')
       .addItem('📚 Tutorials', 'createFullTutorialSystem'))
     .addToUi();

--- a/TaskManagement.js
+++ b/TaskManagement.js
@@ -972,6 +972,35 @@ function formatDate(date) {
 }
 
 /**
+ * Updates the "Related Session" dropdown in the Task Management sheet using
+ * titles from the Schedule sheet.
+ * @param {GoogleAppsScript.Spreadsheet.Spreadsheet} ss The spreadsheet.
+ */
+function updateRelatedSessionDropdown(ss) {
+  if (!ss) ss = SpreadsheetApp.getActiveSpreadsheet();
+  const scheduleSheet = ss.getSheetByName('Schedule');
+  const taskSheet = ss.getSheetByName(TASK_SHEET_NAME);
+
+  if (!scheduleSheet || !taskSheet) {
+    Logger.log('Required sheets not found for Related Session dropdown.');
+    return;
+  }
+
+  const titles = scheduleSheet.getRange('E2:E').getValues()
+    .flat()
+    .filter(String);
+
+  if (titles.length === 0) return;
+
+  const rule = SpreadsheetApp.newDataValidation()
+    .requireValueInList(['General Event', ...new Set(titles)], true)
+    .build();
+
+  taskSheet.getRange(2, 9, taskSheet.getMaxRows() - 1, 1)
+    .setDataValidation(rule);
+}
+
+/**
  * Add menu items to the spreadsheet menu
  * This should be called from your onOpen function
  * @param {Object} menu The menu object to add items to


### PR DESCRIPTION
## Summary
- add routine to update the "Related Session" dropdown on the Task Management sheet
- create `updateAllDropdowns` and a helper trigger creator
- remove manual dropdown refresh option from the menu
- document trigger setup

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845c16936308322babed7eac5feca1f