### PR TITLE
Fix Drive permissions for new planner

### DIFF
--- a/Core.js
+++ b/Core.js
@@ -574,6 +574,8 @@ function createNewEventSpreadsheet() {
   const copyFile = DriveApp.getFileById(current.getId()).makeCopy(name);
   const newSs = SpreadsheetApp.openById(copyFile.getId());
 
+  // Rename the default sheet to avoid deletion errors
+  const firstSheet = newSs.getSheets()[0];
   if (firstSheet) firstSheet.setName('Event Description');
 
   // Create base sheets

--- a/Core.js
+++ b/Core.js
@@ -574,9 +574,12 @@ function createNewEventSpreadsheet() {
   const copyFile = DriveApp.getFileById(current.getId()).makeCopy(name);
   const newSs = SpreadsheetApp.openById(copyFile.getId());
 
-  // Rename the default sheet to avoid deletion errors
+  // Rename the first sheet to "Event Description" if not already present
   const firstSheet = newSs.getSheets()[0];
-  if (firstSheet) firstSheet.setName('Event Description');
+  const descSheet = newSs.getSheetByName('Event Description');
+  if (firstSheet && !descSheet) {
+    firstSheet.setName('Event Description');
+  }
 
   // Create base sheets
   setupEventDescriptionSheet(newSs);

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ LEGIT Event Planner Pro is a Google Apps Script project for managing events dire
    - Store sensitive keys using the Apps Script Properties service rather than directly in the spreadsheet. In the Apps Script editor, go to `Project Settings` ➜ `Script Properties` or run **Event Planner Pro → Save API Key to Script Properties** from the sheet menu to add your keys.
 
 5. **Deploy**
-   ```bash
-   clasp push
-   ```
-   After pushing, open the associated Google Sheet and refresh to load the custom menu.
+  ```bash
+  clasp push
+  ```
+   After pushing, open the associated Google Sheet and refresh to load the custom menu. When first running the script you may be asked to authorize
+   Google Drive access so that new spreadsheets and generated forms can be created.
 
 6. **Initialize Sheets**
    Run the setup functions from the "Event Planner Pro" menu to create the necessary sheets (Config, Schedule, Logistics, Budget, etc.). These provide templates for your event data and settings.

--- a/appsscript.json
+++ b/appsscript.json
@@ -8,7 +8,8 @@
     "https://www.googleapis.com/auth/forms",
     "https://www.googleapis.com/auth/script.scriptapp",
     "https://www.googleapis.com/auth/script.container.ui",
-    "https://www.googleapis.com/auth/gmail.send"
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/drive"
   ],
   "runtimeVersion": "V8",
   "webapp": {


### PR DESCRIPTION
## Summary
- add Google Drive scope to manifest so DriveApp calls are authorized
- document need to authorize Drive access in setup instructions
- add missing variable when copying a planner

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845d85354a4832291ddba5bcca034d5