### PR TITLE
Add configuration dialog integration

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -79,3 +79,99 @@ function setupConfigSheet(ss) {
   
   return configSheet;
 }
+
+/**
+ * Displays the interactive configuration dialog.
+ */
+function showConfigDialog() {
+  const html = HtmlService.createHtmlOutputFromFile('ConfigDialog')
+    .setWidth(600)
+    .setHeight(650);
+  SpreadsheetApp.getUi().showModalDialog(html, 'Event Planner Configuration');
+}
+
+/**
+ * Retrieves configuration settings from the Config sheet.
+ * @return {Object} The configuration values keyed by field name.
+ */
+function getConfiguration() {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName('Config');
+  if (!sheet) {
+    sheet = setupConfigSheet(ss);
+  }
+
+  const data = sheet.getDataRange().getValues();
+  const find = (key, col) => {
+    const row = data.find(r => r[0] === key);
+    return row ? row[col] : '';
+  };
+
+  return {
+    peopleCategories: find('People Categories', 1),
+    peopleStatuses: find('People Statuses', 1),
+    scheduleStatuses: find('Schedule Status Options', 1),
+    taskStatuses: find('Task Status Options', 1),
+    taskPriorities: find('Task Priority Options', 1),
+    locations: find('Location List', 1),
+    owners: find('Owners', 1),
+    lookAheadDays: find('Look-Ahead Days', 1),
+    reminderLeadTime: find('Reminder Lead Time (days)', 1),
+    inviteSubject: find('InviteTemplate', 1),
+    inviteBody: find('InviteTemplate', 2),
+    reminderSubject: find('ReminderTemplate', 1),
+    reminderBody: find('ReminderTemplate', 2),
+    thankYouSubject: find('ThankYouTemplate', 1),
+    thankYouBody: find('ThankYouTemplate', 2)
+  };
+}
+
+/**
+ * Saves configuration data back to the Config sheet.
+ * @param {Object} config Configuration values from the dialog.
+ */
+function saveConfiguration(config) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName('Config');
+  if (!sheet) {
+    sheet = setupConfigSheet(ss);
+  }
+
+  const data = sheet.getDataRange().getValues();
+  const index = {};
+  data.forEach((r, i) => {
+    if (r[0]) index[r[0]] = i + 1;
+  });
+
+  const ensureRow = key => {
+    if (!index[key]) {
+      sheet.appendRow([key, '', '']);
+      index[key] = sheet.getLastRow();
+    }
+    return index[key];
+  };
+
+  const setVal = (key, val) => {
+    const row = ensureRow(key);
+    sheet.getRange(row, 2).setValue(val);
+  };
+
+  const setTemplate = (key, subject, body) => {
+    const row = ensureRow(key);
+    sheet.getRange(row, 2, 1, 2).setValues([[subject, body]]);
+  };
+
+  setVal('People Categories', config.peopleCategories);
+  setVal('People Statuses', config.peopleStatuses);
+  setVal('Schedule Status Options', config.scheduleStatuses);
+  setVal('Task Status Options', config.taskStatuses);
+  setVal('Task Priority Options', config.taskPriorities);
+  setVal('Location List', config.locations);
+  setVal('Owners', config.owners);
+  setVal('Look-Ahead Days', config.lookAheadDays);
+  setVal('Reminder Lead Time (days)', config.reminderLeadTime);
+  setTemplate('InviteTemplate', config.inviteSubject, config.inviteBody);
+  setTemplate('ReminderTemplate', config.reminderSubject, config.reminderBody);
+  setTemplate('ThankYouTemplate', config.thankYouSubject, config.thankYouBody);
+}
+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ LEGIT Event Planner Pro is a Google Apps Script project for managing events dire
 - AI-powered generation of preliminary schedules, tasks, logistics lists, and budgets.
 - Form and email generators to streamline communication. Generated forms are saved in a "[Event Name] Forms" folder next to the spreadsheet.
 - Tools for managing people, schedules, and cues.
+- Interactive configuration dialog for customizing dropdown lists and email templates.
 - Dedicated **AI & Automation Tools** sheet to explain advanced menu options.
 - Modular code organized by feature for easier maintenance.
 

--- a/SmartUX.js
+++ b/SmartUX.js
@@ -159,7 +159,7 @@ function addExpertUserMenu(menu, ui) {
       .addItem('🔗 Generate Forms', 'showFormSelectionDialog')
       .addItem('📧 Send Emails', 'showEmailDialog'))
     .addSubMenu(ui.createMenu('⚙️ Utilities')
-      .addItem('🔧 Configuration', 'setupConfigSheet')
+      .addItem('🔧 Configuration', 'showConfigDialog')
       .addItem('📋 New Event Planner', 'createNewEventSpreadsheet'));
 }
 
@@ -610,7 +610,7 @@ function showProToolsMenu() {
       .addItem('🔗 Generate Forms', 'showFormSelectionDialog')
       .addItem('📧 Send Emails', 'showEmailDialog'))
     .addSubMenu(ui.createMenu('⚙️ Utilities')
-      .addItem('🔧 Configuration', 'setupConfigSheet')
+      .addItem('🔧 Configuration', 'showConfigDialog')
       .addItem('📋 New Event Planner', 'createNewEventSpreadsheet')
       .addItem('📚 Tutorials', 'createFullTutorialSystem'))
     .addToUi();


### PR DESCRIPTION
## Summary
- integrate new ConfigDialog.html into the Apps Script project
- add `showConfigDialog`, `getConfiguration` and `saveConfiguration` helpers
- update menus to open the configuration dialog
- document the configuration dialog in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845f4e0c4d883229e6035d6e7151a76