### PR TITLE
Integrate EventSetupDialog

### DIFF
--- a/SmartUX.js
+++ b/SmartUX.js
@@ -119,6 +119,7 @@ function addNewUserMenu(menu, ui) {
     .addSubMenu(ui.createMenu("🌟 Let's Get Started!")
       .addItem('🚀 2-Minute Setup Wizard', 'startSetupWizard')
       .addItem('📝 Create Event Description', 'setupEventDescriptionSheet')
+      .addItem('🗒️ Quick Event Setup', 'showEventSetupDialog')
       .addSeparator()
       .addItem('📚 Show Me Around (Tutorial)', 'createFullTutorialSystem'))
     .addItem('⚙️ Pro Tools', 'showAdvancedOptionsDialog');


### PR DESCRIPTION
## Summary
- hook up new EventSetupDialog to the menu
- implement server functions to load and save event info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845f80f02688322b3587802b2b24571