### PR TITLE
Increase config dialog size and fonts

### DIFF
--- a/Config.js
+++ b/Config.js
@@ -85,8 +85,8 @@ function setupConfigSheet(ss) {
  */
 function showConfigDialog() {
   const html = HtmlService.createHtmlOutputFromFile('ConfigDialog')
-    .setWidth(600)
-    .setHeight(650);
+    .setWidth(900)
+    .setHeight(975);
   SpreadsheetApp.getUi().showModalDialog(html, 'Event Planner Configuration');
 }
 

--- a/ConfigDialog.html
+++ b/ConfigDialog.html
@@ -33,13 +33,13 @@
         }
 
         .config-header h1 {
-            font-size: 24px;
+            font-size: 26px;
             margin-bottom: 8px;
         }
 
         .config-header p {
             opacity: 0.9;
-            font-size: 14px;
+            font-size: 16px;
         }
 
         .config-body {
@@ -58,7 +58,7 @@
 
         .section h2 {
             color: #495057;
-            font-size: 18px;
+            font-size: 20px;
             margin-bottom: 16px;
             display: flex;
             align-items: center;
@@ -82,18 +82,18 @@
             color: #495057;
             font-weight: 500;
             margin-bottom: 6px;
-            font-size: 14px;
+            font-size: 16px;
         }
 
         .form-group .helper-text {
-            font-size: 12px;
+            font-size: 13px;
             color: #6c757d;
             margin-bottom: 6px;
             line-height: 1.4;
         }
 
         .comma-note {
-            font-size: 11px;
+            font-size: 12px;
             color: #28a745;
             font-weight: 500;
             margin-bottom: 4px;
@@ -113,7 +113,7 @@
             padding: 10px 12px;
             border: 1px solid #ced4da;
             border-radius: 6px;
-            font-size: 14px;
+            font-size: 16px;
             transition: all 0.2s ease;
             font-family: inherit;
         }
@@ -146,7 +146,7 @@
             padding: 10px 20px;
             border-radius: 6px;
             border: none;
-            font-size: 14px;
+            font-size: 16px;
             font-weight: 500;
             cursor: pointer;
             transition: all 0.2s ease;
@@ -183,7 +183,7 @@
             align-items: center;
             gap: 8px;
             color: #667eea;
-            font-size: 14px;
+            font-size: 16px;
         }
 
         .loading.show {
@@ -212,7 +212,7 @@
             border-radius: 6px;
             margin-bottom: 16px;
             display: none;
-            font-size: 14px;
+            font-size: 16px;
         }
 
         .success-message {
@@ -223,7 +223,7 @@
             border-radius: 6px;
             margin-bottom: 16px;
             display: none;
-            font-size: 14px;
+            font-size: 16px;
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- enlarge configuration dialog modal dimensions
- bump font sizes in the configuration dialog for easier reading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845f8f5ba008322a76be50b7d014bb5