### PR TITLE
Fix Event Setup access and getEventDetails error

### DIFF
--- a/ScheduleGenerator.js
+++ b/ScheduleGenerator.js
@@ -27,7 +27,7 @@ function generatePreliminarySchedule() {
   }
   
   // Step 1: Gather event details
-  const eventDetails = getEventDetails(eventDescSheet);
+  const eventDetails = getEventDetailsFromSheet(eventDescSheet);
   if (!eventDetails || !eventDetails.eventName || !eventDetails.startDate || !eventDetails.endDate) {
     ui.alert('Error', 'Required event details (Event Name, Start Date, End Date) are missing. Please complete the Event Description sheet.', ui.ButtonSet.OK);
     return;
@@ -149,7 +149,7 @@ function validateLocation(location, approvedLocations) {
  * @param {GoogleAppsScript.Spreadsheet.Sheet} sheet - The Event Description sheet
  * @return {Object} Event details including name, dates, theme, audience, objectives, descriptions, etc.
  */
-function getEventDetails(sheet) {
+function getEventDetailsFromSheet(sheet) {
   // Get all data from the sheet
   const data = sheet.getDataRange().getValues();
   

--- a/SmartUX.js
+++ b/SmartUX.js
@@ -13,6 +13,7 @@ function smartUXOnOpen() {
   // Always available items
   let menu = ui.createMenu('Event Planner Pro 🚀')
     .addItem('📖 Help & User Guide', 'showContextualHelp')
+    .addItem('🗒️ Quick Event Setup', 'showEventSetupDialog')
     .addItem('💡 Quick Tip for This Sheet', 'showQuickHelp')
     .addItem('📕 User Manual (Google Doc)', 'showUserManual')
     .addSeparator();


### PR DESCRIPTION
## Summary
- expose Quick Event Setup in the main menu
- avoid function name collision by renaming ScheduleGenerator's `getEventDetails`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845fb1201688322b9183b8b97639c67