### PR TITLE
Add optional theme, profit and key message fields

### DIFF
--- a/EventDescription.js
+++ b/EventDescription.js
@@ -90,6 +90,7 @@ function getEventDetails() {
   return {
     eventName: getVal('Event Name'),
     eventDescription: getVal('Description & Messaging'),
+    theme: getVal('Theme or Focus'),
     eventDuration: getVal('Single- or Multi-Day?') || 'single',
     startDate: parseDate(startValue),
     startTime: parseTime(startValue),
@@ -98,7 +99,9 @@ function getEventDetails() {
     venueName: getVal('Location'),
     targetAudience: getVal('Target Audience'),
     eventGoals: getVal('Short Objectives'),
-    expectedAttendees: getVal('Attendance Goal (#)')
+    keyMessages: getVal('Key Messages'),
+    expectedAttendees: getVal('Attendance Goal (#)'),
+    profitGoal: getVal('Profit Goal ($)')
   };
 }
 
@@ -131,6 +134,7 @@ function saveEventDetails(details) {
 
   setVal('Event Name', details.eventName);
   setVal('Description & Messaging', details.eventDescription);
+  setVal('Theme or Focus', details.theme);
   setVal('Single- or Multi-Day?', details.eventDuration);
   setVal('Start Date (And Time)', combineDateTime(details.startDate, details.startTime));
   if (details.endDate || details.endTime) {
@@ -139,7 +143,9 @@ function saveEventDetails(details) {
   setVal('Location', details.venueName || details.virtualLink || '');
   setVal('Target Audience', details.targetAudience);
   setVal('Short Objectives', details.eventGoals);
+  setVal('Key Messages', details.keyMessages);
   setVal('Attendance Goal (#)', details.expectedAttendees);
+  setVal('Profit Goal ($)', details.profitGoal);
 
   return true;
 }

--- a/EventSetupDialog.html
+++ b/EventSetupDialog.html
@@ -363,6 +363,16 @@
                     <div class="helper-text">Provide a detailed description that explains the purpose, activities, and what makes it special</div>
                     <textarea id="eventDescription" placeholder="Describe your event's goals, target audience, key activities, and unique value proposition..."></textarea>
                 </div>
+
+                <div class="form-group">
+                    <label>Does your event have a theme or focus? <span class="optional-tag">(Optional)</span></label>
+                    <input type="text" id="eventTheme" placeholder="e.g., Sustainability, Innovation, Community" />
+                </div>
+
+                <div class="form-group">
+                    <label>What are the key messages you want to communicate? <span class="optional-tag">(Optional)</span></label>
+                    <textarea id="keyMessages" placeholder="e.g., Empower local entrepreneurs; Foster collaboration among nonprofits..."></textarea>
+                </div>
             </div>
 
             <!-- Date & Time Section -->
@@ -532,6 +542,11 @@
                     <div class="helper-text">Define metrics that will help you evaluate the event afterwards</div>
                     <textarea id="successMetrics" placeholder="e.g., Number of attendees, satisfaction survey scores, amount raised, new partnerships formed..."></textarea>
                 </div>
+
+                <div class="form-group">
+                    <label>What's your profit goal ($)? <span class="optional-tag">(Optional)</span></label>
+                    <input type="number" id="profitGoal" min="0" step="0.01" placeholder="e.g., 5000" />
+                </div>
             </div>
 
             <!-- Additional Details Section -->
@@ -639,6 +654,9 @@
                 document.getElementById('eventName').value = details.eventName || '';
                 document.getElementById('eventTagline').value = details.eventTagline || '';
                 document.getElementById('eventDescription').value = details.eventDescription || '';
+                document.getElementById('eventTheme').value = details.theme || '';
+                document.getElementById('keyMessages').value = details.keyMessages || '';
+                document.getElementById('profitGoal').value = details.profitGoal || '';
                 // ... populate other fields as needed
             }
             updateProgress();
@@ -675,10 +693,13 @@
                 venueName: document.getElementById('venueName').value,
                 venueAddress: document.getElementById('venueAddress').value,
                 virtualLink: document.getElementById('virtualLink').value,
+                theme: document.getElementById('eventTheme').value,
                 expectedAttendees: document.getElementById('expectedAttendees').value,
                 targetAudience: document.getElementById('targetAudience').value,
                 eventGoals: document.getElementById('eventGoals').value,
+                keyMessages: document.getElementById('keyMessages').value,
                 successMetrics: document.getElementById('successMetrics').value,
+                profitGoal: document.getElementById('profitGoal').value,
                 specialNotes: document.getElementById('specialNotes').value,
                 eventWebsite: document.getElementById('eventWebsite').value,
                 categories: getSelectedCategories()


### PR DESCRIPTION
## Summary
- update EventSetup dialog with optional fields for theme, profit goal, and key messages
- persist new fields when saving event details
- load new fields when the dialog is opened

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845fc3151a483228a4287a4a992c6fd