### PR TITLE
Add support for extra event setup fields

### DIFF
--- a/EventDescription.js
+++ b/EventDescription.js
@@ -18,18 +18,27 @@ function setupEventDescriptionSheet(ss) {
   const fields = [
     'Event ID',
     'Event Name',
+    'Tagline',
     'Start Date (And Time)',
     'End Date (And Time)',
     'Single- or Multi-Day?',
+    'Timezone',
+    'Event Type',
     'Location',
+    'Venue Address',
+    'Virtual Link',
     'Theme or Focus',
     'Target Audience',
+    'Categories',
     'Short Objectives',
+    'Success Metrics',
     'Description & Messaging',
     'Detailed Description',
     'Key Messages',
     'Attendance Goal (#)',
-    'Profit Goal ($)'
+    'Profit Goal ($)',
+    'Special Notes',
+    'Event Website'
   ];
   sheet.getRange(1, 1, 1, 2).setValues([headers])
     .setBackground('#674ea7')
@@ -89,19 +98,28 @@ function getEventDetails() {
 
   return {
     eventName: getVal('Event Name'),
+    eventTagline: getVal('Tagline'),
     eventDescription: getVal('Description & Messaging'),
     theme: getVal('Theme or Focus'),
     eventDuration: getVal('Single- or Multi-Day?') || 'single',
+    timezone: getVal('Timezone'),
+    eventType: getVal('Event Type'),
     startDate: parseDate(startValue),
     startTime: parseTime(startValue),
     endDate: parseDate(endValue),
     endTime: parseTime(endValue),
     venueName: getVal('Location'),
+    venueAddress: getVal('Venue Address'),
+    virtualLink: getVal('Virtual Link'),
     targetAudience: getVal('Target Audience'),
+    categories: getVal('Categories'),
     eventGoals: getVal('Short Objectives'),
+    successMetrics: getVal('Success Metrics'),
     keyMessages: getVal('Key Messages'),
     expectedAttendees: getVal('Attendance Goal (#)'),
-    profitGoal: getVal('Profit Goal ($)')
+    profitGoal: getVal('Profit Goal ($)'),
+    specialNotes: getVal('Special Notes'),
+    eventWebsite: getVal('Event Website')
   };
 }
 
@@ -133,19 +151,28 @@ function saveEventDetails(details) {
   };
 
   setVal('Event Name', details.eventName);
+  setVal('Tagline', details.eventTagline);
   setVal('Description & Messaging', details.eventDescription);
   setVal('Theme or Focus', details.theme);
   setVal('Single- or Multi-Day?', details.eventDuration);
+  setVal('Timezone', details.timezone);
+  setVal('Event Type', details.eventType);
   setVal('Start Date (And Time)', combineDateTime(details.startDate, details.startTime));
   if (details.endDate || details.endTime) {
     setVal('End Date (And Time)', combineDateTime(details.endDate || details.startDate, details.endTime));
   }
   setVal('Location', details.venueName || details.virtualLink || '');
+  setVal('Venue Address', details.venueAddress);
+  setVal('Virtual Link', details.virtualLink);
   setVal('Target Audience', details.targetAudience);
+  setVal('Categories', details.categories);
   setVal('Short Objectives', details.eventGoals);
+  setVal('Success Metrics', details.successMetrics);
   setVal('Key Messages', details.keyMessages);
   setVal('Attendance Goal (#)', details.expectedAttendees);
   setVal('Profit Goal ($)', details.profitGoal);
+  setVal('Special Notes', details.specialNotes);
+  setVal('Event Website', details.eventWebsite);
 
   return true;
 }

--- a/EventSetupDialog.html
+++ b/EventSetupDialog.html
@@ -648,7 +648,7 @@
                 .getEventDetails();
         };
         
-        function loadEventDetails(details) {
+       function loadEventDetails(details) {
             if (details) {
                 // Populate form fields with existing values
                 document.getElementById('eventName').value = details.eventName || '';
@@ -656,8 +656,33 @@
                 document.getElementById('eventDescription').value = details.eventDescription || '';
                 document.getElementById('eventTheme').value = details.theme || '';
                 document.getElementById('keyMessages').value = details.keyMessages || '';
+                document.querySelector(`input[name="eventDuration"][value="${details.eventDuration || 'single'}"]`).checked = true;
+                document.getElementById('startDate').value = details.startDate || '';
+                document.getElementById('startTime').value = details.startTime || '';
+                document.getElementById('endDate').value = details.endDate || '';
+                document.getElementById('endTime').value = details.endTime || '';
+                document.getElementById('timezone').value = details.timezone || 'EST';
+                document.querySelector(`input[name="eventType"][value="${details.eventType || 'in-person'}"]`).checked = true;
+                document.getElementById('venueName').value = details.venueName || '';
+                document.getElementById('venueAddress').value = details.venueAddress || '';
+                document.getElementById('virtualLink').value = details.virtualLink || '';
+                document.getElementById('expectedAttendees').value = details.expectedAttendees || '';
+                document.getElementById('targetAudience').value = details.targetAudience || '';
+                document.getElementById('eventGoals').value = details.eventGoals || '';
+                document.getElementById('successMetrics').value = details.successMetrics || '';
                 document.getElementById('profitGoal').value = details.profitGoal || '';
-                // ... populate other fields as needed
+                document.getElementById('specialNotes').value = details.specialNotes || '';
+                document.getElementById('eventWebsite').value = details.eventWebsite || '';
+                // Set categories
+                if (details.categories) {
+                    const cats = details.categories.split(',').map(c => c.trim());
+                    document.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+                        cb.checked = cats.includes(cb.value);
+                    });
+                }
+                // Trigger UI toggles
+                document.querySelector(`input[name="eventDuration"][value="${details.eventDuration || 'single'}"]`).dispatchEvent(new Event('change'));
+                document.querySelector(`input[name="eventType"][value="${details.eventType || 'in-person'}"]`).dispatchEvent(new Event('change'));
             }
             updateProgress();
         }
@@ -707,7 +732,7 @@
             
             // Save to spreadsheet
             google.script.run
-                .withSuccessHandler(onSaveSuccess)
+                .withSuccessHandler(function() { onSaveSuccess(eventDetails); })
                 .withFailureHandler(onSaveError)
                 .saveEventDetails(eventDetails);
         }
@@ -720,11 +745,16 @@
             return categories.join(', ');
         }
         
-        function onSaveSuccess() {
+        function onSaveSuccess(savedDetails) {
             document.getElementById('loadingIndicator').classList.remove('show');
             document.getElementById('saveButton').disabled = false;
             document.getElementById('successMessage').textContent = 'Event details saved successfully!';
             document.getElementById('successMessage').style.display = 'block';
+
+            // Refresh form with the saved details
+            if (savedDetails) {
+                loadEventDetails(savedDetails);
+            }
             
             // Update button text
             document.getElementById('saveButton').textContent = 'Update Event';


### PR DESCRIPTION
## Summary
- add rows for new Event Setup fields
- persist and load these extra details
- update setup dialog to handle all fields and keep them on save

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684605346b608322a182c87b712db4a8