### PR TITLE
Fix Related Session dropdown auto-update

### DIFF
--- a/Core.js
+++ b/Core.js
@@ -33,9 +33,16 @@ function onEdit(e) {
   if (sheetName === 'Schedule') {
     // Handle duration calculation for time changes
     handleScheduleEdit(e);
-    
+
     // Handle session status changes to "Confirmed"
     handleSessionStatusChange(e);
+
+    // Update Related Session dropdown when schedule changes
+    try {
+      updateRelatedSessionDropdown(e.source);
+    } catch (err) {
+      Logger.log('Error updating Related Session dropdown: ' + err);
+    }
   }
   
   // Handle People sheet edits for speaker task creation


### PR DESCRIPTION
## Summary
- ensure the Task Management "Related Session" dropdown refreshes whenever the Schedule sheet changes

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6846182caad483229416eeff2333990d