### PR TITLE
Enhance prompts with tagline and metrics

### DIFF
--- a/Budget.js
+++ b/Budget.js
@@ -239,9 +239,12 @@ function generateAIBudget() {
     const prompt =
       `Create a detailed budget for the following event that includes both income and expense categories.\n\n` +
       `Event Name: ${eventInfo.eventName}\n` +
+      `Tagline: ${eventInfo.eventTagline || 'N/A'}\n` +
       `Dates: ${startDate}${eventInfo.endDate ? ' to ' + endDate : ''}\n` +
       `Location: ${eventInfo.location || 'TBD'}\n` +
       `Attendance Goal: ${eventInfo.attendanceGoal}\n\n` +
+      `Success Metrics: ${eventInfo.successMetrics || 'N/A'}\n\n` +
+      `Event Website: ${eventInfo.eventWebsite || 'N/A'}\n\n` +
       `Needed Logistics Items:\n${logisticsText}\n\n` +
       `List any questions about missing costs or assumptions, such as registration fees per person.\n` +
       `Respond with a JSON object {"budget": [ {"category":"Income or Expense","item":"","unitPrice":0,"quantity":0} ], "questions": [] }`;

--- a/EnhancedTaskManagement.js
+++ b/EnhancedTaskManagement.js
@@ -275,12 +275,15 @@ Create coordination and communication tasks for team members.`;
 
 EVENT DETAILS:
 - Name: ${eventInfo.eventName}
+- Tagline: ${eventInfo.eventTagline || 'N/A'}
 - Date(s): ${startDate}${eventInfo.durationDays > 1 ? ` to ${endDate}` : ''}
 - Duration: ${eventInfo.durationDays} day(s)
 - Location: ${eventInfo.location || 'TBD'}
 - Theme: ${eventInfo.theme || 'N/A'}
 - Objectives: ${eventInfo.objectives || 'N/A'}
 - Description: ${eventInfo.description || 'N/A'}${sessionContext}${peopleContext}
+- Success Metrics: ${eventInfo.successMetrics || 'N/A'}
+- Event Website: ${eventInfo.eventWebsite || 'N/A'}
 
 Create tasks in three phases:
 1. PRE-EVENT TASKS (due before ${startDate})

--- a/Logistics.js
+++ b/Logistics.js
@@ -134,9 +134,14 @@ function generateAILogisticsList(selectedItems) {
     // --------------------------------------------------------
 
     const prompt = `Based on the event details below, generate a list of logistical items.
+    Event Name: ${eventInfo.eventName}
+    Tagline: ${eventInfo.eventTagline || 'N/A'}
     The total expected attendance is ${attendanceGoal}. This is a critical number.
 
     **VERY IMPORTANT INSTRUCTION**: Use the attendance goal to calculate a final number for the 'quantity'. Do NOT return ratios like '1 per 25 attendees'. For an attendance of 100 and a recommendation of 1 per 25, you MUST return the calculated number 4.
+
+    Success Metrics: ${eventInfo.successMetrics || 'N/A'}
+    Event Website: ${eventInfo.eventWebsite || 'N/A'}
 
     Focus on the logistics for these specific parts of the event:
     ${scheduleContext}

--- a/TaskManagement.js
+++ b/TaskManagement.js
@@ -21,6 +21,7 @@ function getEventInformation() {
   const eventInfo = {
     eventId: '',
     eventName: '',
+    eventTagline: '',
     startDate: null,
     endDate: null,
     isMultiDay: false,
@@ -30,12 +31,15 @@ function getEventInformation() {
     description: '',
     detailedDescription: '',
     keyMessages: '',
+    successMetrics: '',
+    eventWebsite: '',
     attendanceGoal: 0 // Default to 0
   };
 
   const fieldMap = {
     'Event ID': 'eventId',
     'Event Name': 'eventName',
+    'Tagline': 'eventTagline',
     'Start Date (And Time)': 'startDate',
     'Start Date': 'startDate',
     'End Date (And Time)': 'endDate',
@@ -48,6 +52,8 @@ function getEventInformation() {
     'Description & Messaging': 'description',
     'Detailed Description': 'detailedDescription',
     'Key Messages': 'keyMessages',
+    'Success Metrics': 'successMetrics',
+    'Event Website': 'eventWebsite',
     'Attendance Goal (#)': 'attendanceGoal'
   };
 
@@ -473,6 +479,7 @@ Generate a comprehensive list of tasks for planning and executing the following 
 
 EVENT DETAILS:
 - Name: ${eventInfo.eventName}
+- Tagline: ${eventInfo.eventTagline || 'N/A'}
 - Date(s): ${startDate}${eventInfo.durationDays > 1 ? ` to ${endDate}` : ''}
 - Duration: ${eventInfo.durationDays} day(s)
 - Location: ${eventInfo.location || 'TBD'}
@@ -481,6 +488,8 @@ EVENT DETAILS:
 - Description: ${eventInfo.description || 'N/A'}
 - Detailed Description: ${eventInfo.detailedDescription || 'N/A'}
 - Key Messages: ${eventInfo.keyMessages || 'N/A'}
+- Success Metrics: ${eventInfo.successMetrics || 'N/A'}
+- Event Website: ${eventInfo.eventWebsite || 'N/A'}
 
 Please create a comprehensive task list divided into three phases:
 1. PRE-EVENT TASKS (tasks to complete before ${startDate}, with most due ${DEFAULT_PRE_EVENT_DAYS} days before)


### PR DESCRIPTION
## Summary
- extend event info parsing with tagline, success metrics and website
- include new details in schedule, task, budget and logistics prompts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846091968d48322b0278434a67c4cb3