### PR TITLE
Add AI email tools

### DIFF
--- a/MailMerge.js
+++ b/MailMerge.js
@@ -108,3 +108,110 @@ function sendEmails(filters) {
   }
 }
 
+
+/**
+ * Generates an email subject and body using OpenAI based on event information.
+ * The returned strings include a {{Name}} placeholder for personalization.
+ * @param {string} prompt Additional instructions for the AI.
+ * @return {Object} Object with `subject` and `body` keys.
+ */
+function generateEmailWithAI(prompt) {
+  try {
+    const apiKey = getOpenAIApiKey();
+    if (!apiKey) throw new Error('OpenAI API key not found.');
+
+    const eventInfo = getEventInformation();
+    if (!eventInfo) throw new Error('Event information not available.');
+
+    const start = eventInfo.startDate ? Utilities.formatDate(new Date(eventInfo.startDate), Session.getScriptTimeZone(), "yyyy-MM-dd") : "";
+    const end = eventInfo.endDate ? Utilities.formatDate(new Date(eventInfo.endDate), Session.getScriptTimeZone(), "yyyy-MM-dd") : "";
+    let context = `Event Name: ${eventInfo.eventName}\n` +
+                  `Dates: ${start}${eventInfo.durationDays > 1 ? ' to ' + end : ''}\n` +
+                  `Location: ${eventInfo.location || 'TBD'}`;
+    if (eventInfo.description) context += `\nDescription: ${eventInfo.description}`;
+
+    const fullPrompt = `${prompt}\n\nEVENT INFORMATION:\n${context}\n\n` +
+      'Return a JSON object {"subject":"","body":""} ' +
+      'and use {{Name}} where the recipient name should appear.';
+
+    const url = 'https://api.openai.com/v1/chat/completions';
+    const payload = {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: fullPrompt }],
+      response_format: { type: 'json_object' }
+    };
+    const options = {
+      method: 'post',
+      contentType: 'application/json',
+      headers: { Authorization: 'Bearer ' + apiKey },
+      payload: JSON.stringify(payload),
+      muteHttpExceptions: true
+    };
+
+    const response = UrlFetchApp.fetch(url, options);
+    if (response.getResponseCode() !== 200) {
+      throw new Error(`OpenAI API Error (${response.getResponseCode()}): ${response.getContentText()}`);
+    }
+
+    const parsed = JSON.parse(response.getContentText());
+    const content = JSON.parse(parsed.choices[0].message.content);
+    return { subject: content.subject || '', body: content.body || '' };
+  } catch (e) {
+    Logger.log(e);
+    return { subject: '', body: '' };
+  }
+}
+
+/**
+ * Saves or updates an email template in the Config sheet under "EMAIL TEMPLATES".
+ * @param {string} name Template name/key.
+ * @param {string} subject Subject line text.
+ * @param {string} body Body text.
+ */
+function saveEmailTemplate(name, subject, body) {
+  try {
+    const ss = SpreadsheetApp.getActiveSpreadsheet();
+    const sheet = ss.getSheetByName('Config');
+    if (!sheet) throw new Error('Config sheet not found.');
+
+    const data = sheet.getDataRange().getValues();
+    let emailHeaderRow = -1;
+    let nextSectionRow = data.length + 1;
+    let existingRow = -1;
+
+    for (let i = 0; i < data.length; i++) {
+      const cell = data[i][0];
+      if (cell === name) existingRow = i + 1;
+      if (cell === '--- EMAIL TEMPLATES ---') {
+        emailHeaderRow = i + 1;
+        for (let j = i + 1; j < data.length; j++) {
+          const val = data[j][0];
+          if (val && val.toString().startsWith('---')) {
+            nextSectionRow = j + 1;
+            break;
+          }
+        }
+      }
+    }
+
+    if (existingRow !== -1) {
+      sheet.getRange(existingRow, 1, 1, 3).setValues([[name, subject, body]]);
+      return;
+    }
+
+    if (emailHeaderRow === -1) {
+      sheet.appendRow([name, subject, body]);
+      return;
+    }
+
+    if (nextSectionRow > data.length) {
+      sheet.appendRow([name, subject, body]);
+    } else {
+      sheet.insertRows(nextSectionRow, 1);
+      sheet.getRange(nextSectionRow, 1, 1, 3).setValues([[name, subject, body]]);
+    }
+  } catch (e) {
+    Logger.log('Error saving email template: ' + e.toString());
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `generateEmailWithAI` to create email subject and body using OpenAI
- add `saveEmailTemplate` to manage templates in Config sheet

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846384d7d4c8322a41713c562505724