### PR TITLE
Switch to gpt-4.1-mini for all AI calls

### DIFF
--- a/Budget.js
+++ b/Budget.js
@@ -251,7 +251,7 @@ function generateAIBudget() {
 
     const url = 'https://api.openai.com/v1/chat/completions';
     const payload = {
-      model: 'gpt-4o',
+      model: 'gpt-4.1-mini',
       messages: [{ role: 'user', content: prompt }],
       response_format: { type: 'json_object' }
     };

--- a/EnhancedTaskManagement.js
+++ b/EnhancedTaskManagement.js
@@ -325,7 +325,7 @@ Focus on creating actionable, specific tasks rather than generic ones. Each sess
     // Call OpenAI API with enhanced prompt
     const url = 'https://api.openai.com/v1/chat/completions';
     const payload = {
-      model: "gpt-3.5-turbo",
+      model: "gpt-4.1-mini",
       messages: [
         {
           role: "system",

--- a/Logistics.js
+++ b/Logistics.js
@@ -161,7 +161,7 @@ function generateAILogisticsList(selectedItems) {
 
     const url = 'https://api.openai.com/v1/chat/completions';
     const payload = {
-      model: "gpt-4o",
+      model: "gpt-4.1-mini",
       messages: [{ "role": "user", "content": prompt }],
       response_format: { "type": "json_object" }
     };

--- a/MailMerge.js
+++ b/MailMerge.js
@@ -144,7 +144,7 @@ function generateEmailWithAI(prompt) {
 
     const url = 'https://api.openai.com/v1/chat/completions';
     const payload = {
-      model: 'gpt-4o',
+      model: 'gpt-4.1-mini',
       messages: [{ role: 'user', content: fullPrompt }],
       response_format: { type: 'json_object' }
     };

--- a/ScheduleGenerator.js
+++ b/ScheduleGenerator.js
@@ -603,7 +603,7 @@ function callOpenAIForSchedule(prompt, apiKey, eventDetails, approvedLocations) 
   const url = 'https://api.openai.com/v1/chat/completions';
   
   const payload = {
-    model: "gpt-3.5-turbo-16k",
+    model: "gpt-4.1-mini",
     messages: [
       {
         role: "system", 

--- a/TaskManagement.js
+++ b/TaskManagement.js
@@ -435,7 +435,7 @@ function testApiKey() {
     // Make a simple API call
     const url = 'https://api.openai.com/v1/chat/completions';
     const payload = {
-      model: "gpt-3.5-turbo",
+      model: "gpt-4.1-mini",
       messages: [{ role: "user", content: "Hello" }],
       max_tokens: 10
     };
@@ -525,7 +525,7 @@ IMPORTANT: Include a diverse range of tasks covering all necessary aspects of ev
     // Call OpenAI API
     const url = 'https://api.openai.com/v1/chat/completions';
     const payload = {
-      model: "gpt-3.5-turbo",
+      model: "gpt-4.1-mini",
       messages: [
         {
           role: "system",


### PR DESCRIPTION
## Summary
- use `gpt-4.1-mini` in Budget.js
- use `gpt-4.1-mini` in EnhancedTaskManagement.js
- use `gpt-4.1-mini` in ScheduleGenerator.js
- use `gpt-4.1-mini` in TaskManagement.js
- use `gpt-4.1-mini` in Logistics.js
- use `gpt-4.1-mini` in MailMerge.js

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68463b7183148322a6560d157fba4dd0