### PR TITLE
Remove new user onboarding submenu

### DIFF
--- a/SmartUX.js
+++ b/SmartUX.js
@@ -115,13 +115,8 @@ function checkForGeneratedContent() {
  * Menu for brand new users
  */
 function addNewUserMenu(menu, ui) {
+  // The onboarding submenu has been removed to streamline the interface
   return menu
-    .addSubMenu(ui.createMenu("🌟 Let's Get Started!")
-      .addItem('🚀 2-Minute Setup Wizard', 'startSetupWizard')
-      .addItem('📝 Create Event Description', 'setupEventDescriptionSheet')
-      .addItem('🗒️ Quick Event Setup', 'showEventSetupDialog')
-      .addSeparator()
-    )
     .addItem('⚙️ Pro Tools', 'showAdvancedOptionsDialog');
 }
 


### PR DESCRIPTION
## Summary
- streamline the new user menu

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c1ea28e3883228f74ec91ef4be973