### PR TITLE
Handle missing event info in cue sheet generation

### DIFF
--- a/GenerateCueSheet.js
+++ b/GenerateCueSheet.js
@@ -16,6 +16,10 @@ function generateProfessionalCueSheet() {
     }
 
     const eventInfo = getEventInformation(); // From TaskManagement.js
+    if (!eventInfo) {
+      ui.alert('Error', 'Could not retrieve event information. Please ensure the "Event Description" sheet is filled out correctly.', ui.ButtonSet.OK);
+      return;
+    }
     const sheetName = `${eventInfo.eventName || 'Event'} - Cue Sheet`;
 
     // Create or clear the cue sheet


### PR DESCRIPTION
## Summary
- check for missing event details when generating a cue sheet

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68535a5594288322a5b0bc552d85136e